### PR TITLE
allow validation_method to be optional

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -53,13 +53,13 @@ variable "subject_alternative_names" {
 }
 
 variable "validation_method" {
-  description = "Which method to use for validation. DNS or EMAIL are valid, NONE can be used for certificates that were imported into ACM and then into Terraform."
+  description = "Which method to use for validation. DNS or EMAIL are valid, null can be used for certificates that were imported into ACM and then into Terraform."
   type        = string
   default     = "DNS"
 
   validation {
-    condition     = contains(["DNS", "EMAIL", "NONE"], var.validation_method)
-    error_message = "Valid values are DNS, EMAIL or NONE."
+    condition     = contains(["DNS", "EMAIL", null], var.validation_method)
+    error_message = "Valid values are DNS, EMAIL or null."
   }
 }
 


### PR DESCRIPTION
Value NONE is no longer supported, reported https://github.com/terraform-aws-modules/terraform-aws-acm/issues/133